### PR TITLE
Fixing missing dynamic reconfigure headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,9 @@ add_library(${PROJECT_NAME}_nodelet
 
 add_executable(${PROJECT_NAME}_node src/${PROJECT_NAME}_node.cpp)
 
+add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_dependencies(${PROJECT_NAME}_nodelet ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 target_link_libraries(${PROJECT_NAME}_node
   ${PROJECT_NAME}


### PR DESCRIPTION
I have not been able to reproduce the problems as described in #3 , however as per [this forum post](https://answers.ros.org/question/285772/dynamic-reconfigure-headers-not-generated/), and given that the issue appears to have been caused by the addition of the nodeletized version, I've added the headers as dependencies to both the generated library and the nodelet executable. 